### PR TITLE
fix: improve isAimable method

### DIFF
--- a/src/main/kotlin/com/dp/advancedgunnerycontrol/weaponais/AGCUitls.kt
+++ b/src/main/kotlin/com/dp/advancedgunnerycontrol/weaponais/AGCUitls.kt
@@ -23,7 +23,8 @@ fun isPD(weapon: WeaponAPI): Boolean {
 }
 
 fun isAimable(weapon: WeaponAPI): Boolean {
-    return !weapon.hasAIHint(WeaponAPI.AIHints.DO_NOT_AIM)
+    return weapon.spec?.trackingStr?.toLowerCase() in setOf(null, "", "none") &&
+            !(weapon.hasAIHint(WeaponAPI.AIHints.DO_NOT_AIM))
 }
 
 fun isInvalid(aiPlugin: AutofireAIPlugin): Boolean {

--- a/src/main/kotlin/com/dp/advancedgunnerycontrol/weaponais/SpecificAIPluginBase.kt
+++ b/src/main/kotlin/com/dp/advancedgunnerycontrol/weaponais/SpecificAIPluginBase.kt
@@ -200,7 +200,7 @@ abstract class SpecificAIPluginBase(
     }
 
     protected fun isWithinArc(entity: CombatEntityAPI): Boolean {
-        if (!isAimable(weapon) || weapon.spec.trackingStr != null) return true
+        if (!isAimable(weapon)) return true
         return isWithinArc(entity.location, effectiveCollRadius(entity))
     }
 
@@ -244,7 +244,7 @@ abstract class SpecificAIPluginBase(
     }
 
     protected open fun computeIfShouldFire(potentialTargets: List<Pair<CombatEntityAPI, Vector2f>>): Boolean {
-        if (!isAimable(weapon) || weapon.spec.trackingStr != null) {
+        if (!isAimable(weapon)) {
             return potentialTargets.isNotEmpty()
         }
 


### PR DESCRIPTION
`if (!isAimable(weapon) || weapon.spec.trackingStr != null)` caused aimable weapons with `None` tracking string to be treated as non-aimable. With some tag combinations it caused e.g. Reapers or Annihilators to be launched into thin air, if enemy was nearby, but not in line of attack.

Checking `weapon.spec.trackingStr` was moved into `isAimable` method, as it seems its responsibility and removes code duplication. Note: the change influences `SpecificAIPluginBase:computePointToAimAt` method.