### PR TITLE
misc: added FiringSolution data class (#2)

### DIFF
--- a/src/main/kotlin/com/dp/advancedgunnerycontrol/weaponais/AGCUtils.kt
+++ b/src/main/kotlin/com/dp/advancedgunnerycontrol/weaponais/AGCUtils.kt
@@ -14,6 +14,15 @@ import kotlin.math.*
 // Math.toRadians only works on doubles, which is annoying....
 const val degToRad: Float = PI.toFloat() / 180f
 
+data class FiringSolution(
+    val target: CombatEntityAPI,
+
+    // Point at which the weapon should aim to hit
+    // the target dead center, under the assumption
+    // that target velocity is constant.
+    val aimPoint: Vector2f
+)
+
 fun isPD(weapon: WeaponAPI): Boolean {
     if (weapon.hasAIHint(WeaponAPI.AIHints.PD_ALSO) || weapon.hasAIHint(WeaponAPI.AIHints.PD)
         || weapon.hasAIHint(WeaponAPI.AIHints.PD_ONLY)
@@ -73,9 +82,9 @@ fun getNeutralPosition(weapon: WeaponAPI) : Vector2f{
     return weapon.location + (vectorFromAngleDeg(weapon.ship.facing) times_ 100f)
 }
 
-fun isOpportuneTarget(tgt : CombatEntityAPI?, predictedLocation: Vector2f?, weapon: WeaponAPI) : Boolean{
-    val target = tgt as? ShipAPI ?: return false
-    val p = predictedLocation ?: return false
+fun isOpportuneTarget(solution: FiringSolution?, weapon: WeaponAPI) : Boolean{
+    val target = solution?.target as? ShipAPI ?: return false
+    val p = solution.aimPoint
     if(!isOpportuneType(target, weapon)) return false
     var trackingFactor = when (weapon.spec?.trackingStr?.toLowerCase()){
         "none" -> 1.0f

--- a/src/main/kotlin/com/dp/advancedgunnerycontrol/weaponais/SpecificAIPluginBase.kt
+++ b/src/main/kotlin/com/dp/advancedgunnerycontrol/weaponais/SpecificAIPluginBase.kt
@@ -7,11 +7,10 @@ package com.dp.advancedgunnerycontrol.weaponais
 import com.dp.advancedgunnerycontrol.settings.Settings
 import com.dp.advancedgunnerycontrol.typesandvalues.Values
 import com.dp.advancedgunnerycontrol.utils.*
-import com.fs.starfarer.api.Global
 import com.fs.starfarer.api.combat.*
 import org.lazywizard.lazylib.combat.CombatUtils
-import org.lazywizard.lazylib.ext.minus
 import org.lazywizard.lazylib.ext.plus
+import org.lazywizard.lazylib.ext.minus
 import org.lwjgl.util.vector.Vector2f
 import kotlin.math.*
 
@@ -19,9 +18,8 @@ abstract class SpecificAIPluginBase(
     val baseAI: AutofireAIPlugin,
     private val customAIActive: Boolean = Settings.enableCustomAI()
 ) : AutofireAIPlugin {
-    protected var targetEntity: CombatEntityAPI? = null
+    protected var solution: FiringSolution? = null
     private var lastTargetEntity: CombatEntityAPI? = null
-    protected var targetPoint: Vector2f? = null
     private var forceOff = false
     private val weapon = baseAI.weapon
     private var weaponShouldFire = false
@@ -34,7 +32,7 @@ abstract class SpecificAIPluginBase(
      * hint: use computeBasePriority
      * simply use return 0f if isBaseAIOverwritable = false
      */
-    protected abstract fun computeTargetPriority(entity: CombatEntityAPI, predictedLocation: Vector2f): Float
+    protected abstract fun computeTargetPriority(solution: FiringSolution): Float
 
     /**
      * @return all enemy entities within weapon range and arc
@@ -64,11 +62,10 @@ abstract class SpecificAIPluginBase(
      * gets called at start of every advancement frame
      */
     private fun reset() {
-        determineTargetLeadingAccuracy(targetEntity, lastTargetEntity)
-        lastTargetEntity = targetEntity
-        targetEntity = null
+        determineTargetLeadingAccuracy(solution?.target, lastTargetEntity)
+        lastTargetEntity = solution?.target
+        solution = null
         forceOff = false
-        targetPoint = null
         weaponShouldFire = false
     }
 
@@ -83,9 +80,11 @@ abstract class SpecificAIPluginBase(
     protected fun advanceBaseAI(p0: Float): Boolean {
         if (Settings.forceCustomAI() && isBaseAIOverwritable()) return false
         baseAI.advance(p0)
-        if (isBaseAITargetValid(baseAI.targetShip, baseAI.targetMissile)) {
-            baseAI.targetMissile?.let { targetEntity = it } ?: baseAI.targetShip?.let { targetEntity = it }
-            baseAI.target?.let { targetPoint = it }
+        val ship = baseAI.targetShip
+        val missile = baseAI.targetMissile
+        val targetEntity = ship as? CombatEntityAPI ?: missile as? CombatEntityAPI
+        if (targetEntity != null && baseAI.target != null && isBaseAITargetValid(ship, missile)) {
+            solution = FiringSolution(targetEntity, baseAI.target)
             weaponShouldFire = baseAI.shouldFire()
             return true
         }
@@ -93,33 +92,29 @@ abstract class SpecificAIPluginBase(
     }
 
     protected fun advanceWithCustomAI() {
-
-        var potentialTargets = addPredictedLocationToTargets(
+        var potentialTargets = calculateFiringSolutions(
             getRelevantEntitiesWithinRange().filter { isHostile(it) }
-        ).filter { isInRange(it.second, effectiveCollRadius(it.first)) }
+        ).filter { isInRange(it.aimPoint, effectiveCollRadius(it.target)) }
 
         // TODO: It would be faster to get friendlies and foes in one go
         if (Settings.customAIFriendlyFireComplexity() >= 2) {
             // this is a deceptively expensive call (therefore locked behind opt-in setting)
-            potentialTargets = potentialTargets.filter { !isFriendlyFire(getFriendlies(), it.second) }
-        }
-        val bestTarget = potentialTargets.minByOrNull {
-            computeTargetPriority(it.first, it.second)
+            potentialTargets = potentialTargets.filter { !isFriendlyFire(getFriendlies(), it.aimPoint) }
         }
 
-        targetEntity = bestTarget?.first
-        targetPoint = bestTarget?.second ?: getNeutralPosition(weapon)
+        solution = potentialTargets.minByOrNull { computeTargetPriority(it) }
+
         computeIfShouldFire(potentialTargets).let {
             weaponShouldFire = it
         }
     }
 
-    protected open fun getFriendlies(): List<Pair<CombatEntityAPI, Vector2f>> {
-        return addPredictedLocationToTargets(
+    protected open fun getFriendlies(): List<FiringSolution> {
+        return calculateFiringSolutions(
             CombatUtils.getShipsWithinRange(weapon.location, weapon.range).filter { it != weapon.ship }.filter {
                 (it.isAlly || (it.owner == 0) || (it.owner == 100 && shouldConsiderNeutralsAsFriendlies())) && !it.isFighter
-            }).filter { isInRange(it.second, effectiveCollRadius(it.first) * Settings.customAIFriendlyFireCaution())
-                && isWithinArc(it.second, effectiveCollRadius(it.first) * Settings.customAIFriendlyFireCaution()) }
+            }).filter { isInRange(it.aimPoint, effectiveCollRadius(it.target) * Settings.customAIFriendlyFireCaution())
+                && isWithinArc(it.aimPoint, effectiveCollRadius(it.target) * Settings.customAIFriendlyFireCaution()) }
     }
 
     protected fun determineTargetLeadingAccuracy(currentTarget: CombatEntityAPI?, lastTarget: CombatEntityAPI?) {
@@ -140,9 +135,9 @@ abstract class SpecificAIPluginBase(
     }
 
     // compensates for both player ship and target velocities
-    protected fun addPredictedLocationToTargets(potentialTargets: List<CombatEntityAPI>): List<Pair<CombatEntityAPI, Vector2f>> {
+    protected fun calculateFiringSolutions(potentialTargets: List<CombatEntityAPI>): List<FiringSolution> {
         return potentialTargets.map {
-            Pair(it, computePointToAimAt(it))
+            FiringSolution(it, computePointToAimAt(it))
         }
     }
 
@@ -152,7 +147,7 @@ abstract class SpecificAIPluginBase(
     }
 
     override fun getTarget(): Vector2f? {
-        return targetPoint
+        return solution?.aimPoint ?: getNeutralPosition(weapon)
     }
 
     override fun getWeapon(): WeaponAPI {
@@ -193,11 +188,11 @@ abstract class SpecificAIPluginBase(
     }
 
     override fun getTargetShip(): ShipAPI? {
-        return targetEntity as? ShipAPI
+        return solution?.target as? ShipAPI
     }
 
     override fun getTargetMissile(): MissileAPI? {
-        return targetEntity as? MissileAPI
+        return solution?.target as? MissileAPI
     }
 
     protected fun isWithinArc(entity: CombatEntityAPI): Boolean {
@@ -214,24 +209,24 @@ abstract class SpecificAIPluginBase(
     protected open fun shouldConsiderNeutralsAsFriendlies(): Boolean = true
 
     // if aimPoint == null, the current weapon facing will be used
-    protected fun isFriendlyFire(friendlies: List<Pair<CombatEntityAPI, Vector2f>>, aimPoint: Vector2f? = null): Boolean = when {
+    protected fun isFriendlyFire(friendlies: List<FiringSolution>, aimPoint: Vector2f? = null): Boolean = when {
         weapon.spec.weaponId == "guardian" -> false // Paladin PD can shoot over friendlies
         !isAimable(weapon) -> false                 // Guided missiles can shoot over friendlies
         friendliesInDangerZone(friendlies, aimPoint).isEmpty() -> false
         else -> true
     }
 
-    protected fun friendliesInDangerZone(friendlies: List<Pair<CombatEntityAPI, Vector2f>>, aimPoint: Vector2f? = null):
-            List<Pair<CombatEntityAPI, Vector2f>> {
+    protected fun friendliesInDangerZone(friendlies: List<FiringSolution>, aimPoint: Vector2f? = null):
+            List<FiringSolution> {
 
         return friendlies.filter {
-            val isCloserThanTgt = targetPoint?.let { tp ->  linearDistanceFromWeapon(it.second, weapon) < linearDistanceFromWeapon(tp, weapon)} ?: true
-            determineIfShotWillHit(it.second, effectiveCollRadius(it.first) * Settings.customAIFriendlyFireCaution(), weapon, aimPoint) &&
+            val isCloserThanTgt = solution?.aimPoint?.let { tp -> linearDistanceFromWeapon(it.aimPoint, weapon) < linearDistanceFromWeapon(tp, weapon)} ?: true
+            determineIfShotWillHit(it.aimPoint, effectiveCollRadius(it.target) * Settings.customAIFriendlyFireCaution(), weapon, aimPoint) &&
                     isCloserThanTgt
         }
     }
 
-    protected open fun computeIfShouldFire(potentialTargets: List<Pair<CombatEntityAPI, Vector2f>>): Boolean {
+    protected open fun computeIfShouldFire(potentialTargets: List<FiringSolution>): Boolean {
         if (!isAimable(weapon)) {
             return potentialTargets.isNotEmpty()
         }
@@ -240,9 +235,9 @@ abstract class SpecificAIPluginBase(
             if (isFriendlyFire(getFriendlies())) return false
         }
         // Note: In a sequence, all calculations are done on the first element before moving to the next
-        potentialTargets.asSequence().filter { isInRange(it.second, effectiveCollRadius(it.first)) }.iterator().forEach {
-            val effectiveCollisionRadius = effectiveCollRadius(it.first) * aimingToleranceFactor + aimingToleranceFlat
-            if(determineIfShotWillHit(it.second, effectiveCollisionRadius, weapon)) return true
+        potentialTargets.asSequence().filter { isInRange(it.aimPoint, effectiveCollRadius(it.target)) }.iterator().forEach {
+            val effectiveCollisionRadius = effectiveCollRadius(it.target) * aimingToleranceFactor + aimingToleranceFlat
+            if(determineIfShotWillHit(it.aimPoint, effectiveCollisionRadius, weapon)) return true
         }
 
         return false
@@ -257,14 +252,14 @@ abstract class SpecificAIPluginBase(
      * @brief compute a priority number for a target based on lin/angular distance, whether it's the ship target etc
      * @return low (>=0) number for high priority targets, high number for low priority targets
      */
-    protected fun computeBasePriority(entity: CombatEntityAPI, predictedLocation: Vector2f): Float {
-        return predictedLocation.let {
+    protected fun computeBasePriority(solution: FiringSolution): Float {
+        return solution.aimPoint.let {
             angularDistanceFromWeapon(it, weapon) + Values.distToAngularDistEvaluationFactor * linearDistanceFromWeapon(it, weapon) + 1.5f
         }.let {
-            if (lastTargetEntity == entity) it * 0.5f else it // incentivize sticking to one target
+            if (lastTargetEntity == solution.target) it * 0.5f else it // incentivize sticking to one target
         } *
-                (if(entity as? ShipAPI == weapon.ship.shipTarget) 0.05f else 1.0f) * // heavily incentivize targeting the ship target
-                (if((entity as? ShipAPI)?.isFighter == false) 1.0f else 1.2f) // prioritize regular ships over other stuff
+                (if(solution.target as? ShipAPI == weapon.ship.shipTarget) 0.05f else 1.0f) * // heavily incentivize targeting the ship target
+                (if((solution.target as? ShipAPI)?.isFighter == false) 1.0f else 1.2f) // prioritize regular ships over other stuff
     }
 
     override fun shouldFire(): Boolean {

--- a/src/main/kotlin/com/dp/advancedgunnerycontrol/weaponais/TagBasedAI.kt
+++ b/src/main/kotlin/com/dp/advancedgunnerycontrol/weaponais/TagBasedAI.kt
@@ -26,9 +26,9 @@ class TagBasedAI(baseAI: AutofireAIPlugin, tags: MutableList<WeaponAITagBase> = 
         this.tags = tags
     }
 
-    override fun computeTargetPriority(entity: CombatEntityAPI, predictedLocation: Vector2f): Float {
-        return computeBasePriority(entity, predictedLocation) *
-                (tags.map { it.computeTargetPriorityModifier(entity, predictedLocation) }.reduceOrNull(Float::times)
+    override fun computeTargetPriority(solution: FiringSolution): Float {
+        return computeBasePriority(solution) *
+                (tags.map { it.computeTargetPriorityModifier(solution) }.reduceOrNull(Float::times)
                     ?: 1.0f)
     }
 
@@ -52,11 +52,10 @@ class TagBasedAI(baseAI: AutofireAIPlugin, tags: MutableList<WeaponAITagBase> = 
 
     override fun shouldFire(): Boolean {
         val baseDecision = super.shouldFire()
-        if(tags.any { it.forceFire(targetEntity, targetPoint, baseDecision) }) return true
+        if(tags.any { it.forceFire(solution, baseDecision) }) return true
         if (!baseDecision) return false
-        val tgt = targetEntity ?: return false
-        val loc = targetPoint ?: return false
-        return tags.all { it.shouldFire(tgt, loc) }
+        val sol = solution ?: return false
+        return tags.all { it.shouldFire(sol) }
     }
 
     override fun shouldConsiderNeutralsAsFriendlies(): Boolean {

--- a/src/main/kotlin/com/dp/advancedgunnerycontrol/weaponais/tags/AvoidArmorTag.kt
+++ b/src/main/kotlin/com/dp/advancedgunnerycontrol/weaponais/tags/AvoidArmorTag.kt
@@ -14,14 +14,14 @@ class AvoidArmorTag(weapon: WeaponAPI, private val armorThreshold: Float = 0.33f
         return computeArmorEffectiveness(entity)  > (armorThreshold * 2f)
     }
 
-    override fun computeTargetPriorityModifier(entity: CombatEntityAPI, predictedLocation: Vector2f): Float {
-        return 1f / (computeArmorEffectiveness(entity, predictedLocation) + 0.1f)
+    override fun computeTargetPriorityModifier(solution: FiringSolution): Float {
+        return 1f / (computeArmorEffectiveness(solution.target, solution.aimPoint) + 0.1f)
     }
 
-    override fun shouldFire(entity: CombatEntityAPI, predictedLocation: Vector2f): Boolean {
-        val ttt = computeTimeToTravel(weapon, predictedLocation)
-        val armorEffectiveness = computeArmorEffectiveness(entity, predictedLocation)
-        return (computeShieldFactor(entity, weapon, ttt) > shieldThreshold) || (armorEffectiveness > armorThreshold)
+    override fun shouldFire(solution: FiringSolution): Boolean {
+        val ttt = computeTimeToTravel(weapon, solution.aimPoint)
+        val armorEffectiveness = computeArmorEffectiveness(solution.target, solution.aimPoint)
+        return (computeShieldFactor(solution.target, weapon, ttt) > shieldThreshold) || (armorEffectiveness > armorThreshold)
     }
 
     override fun isBaseAiOverridable(): Boolean = true

--- a/src/main/kotlin/com/dp/advancedgunnerycontrol/weaponais/tags/AvoidDebrisTag.kt
+++ b/src/main/kotlin/com/dp/advancedgunnerycontrol/weaponais/tags/AvoidDebrisTag.kt
@@ -1,13 +1,14 @@
 package com.dp.advancedgunnerycontrol.weaponais.tags
 
+import com.dp.advancedgunnerycontrol.weaponais.FiringSolution
 import com.fs.starfarer.api.combat.CombatEntityAPI
 import com.fs.starfarer.api.combat.WeaponAPI
 import org.lwjgl.util.vector.Vector2f
 
 class AvoidDebrisTag(weapon: WeaponAPI) : WeaponAITagBase(weapon) {
-    override fun computeTargetPriorityModifier(entity: CombatEntityAPI, predictedLocation: Vector2f): Float = 1.0f
+    override fun computeTargetPriorityModifier(solution: FiringSolution): Float = 1.0f
 
-    override fun shouldFire(entity: CombatEntityAPI, predictedLocation: Vector2f): Boolean = true
+    override fun shouldFire(solution: FiringSolution): Boolean = true
 
     override fun isBaseAiOverridable(): Boolean = true
 

--- a/src/main/kotlin/com/dp/advancedgunnerycontrol/weaponais/tags/AvoidShieldsAtFTTag.kt
+++ b/src/main/kotlin/com/dp/advancedgunnerycontrol/weaponais/tags/AvoidShieldsAtFTTag.kt
@@ -1,12 +1,12 @@
 package com.dp.advancedgunnerycontrol.weaponais.tags
 
 import com.dp.advancedgunnerycontrol.settings.Settings
+import com.dp.advancedgunnerycontrol.weaponais.FiringSolution
 import com.dp.advancedgunnerycontrol.weaponais.computeShieldFactor
 import com.dp.advancedgunnerycontrol.weaponais.computeTimeToTravel
 import com.fs.starfarer.api.combat.CombatEntityAPI
 import com.fs.starfarer.api.combat.ShipAPI
 import com.fs.starfarer.api.combat.WeaponAPI
-import org.lwjgl.util.vector.Vector2f
 
 // Allows targeting of anything when flux < fluxThreshold, otherwise avoids shields. Always prioritises by target shield factor
 class AvoidShieldsAtFTTag(
@@ -22,19 +22,19 @@ class AvoidShieldsAtFTTag(
             computeShieldFactor(entity, weapon) < shieldThreshold
         }
     }
-    override fun computeTargetPriorityModifier(entity: CombatEntityAPI, predictedLocation: Vector2f): Float {
-        return computeShieldFactor(entity, weapon) + 0.1f
+    override fun computeTargetPriorityModifier(solution: FiringSolution): Float {
+        return computeShieldFactor(solution.target, weapon) + 0.1f
     }
 
-    override fun shouldFire(entity: CombatEntityAPI, predictedLocation: Vector2f): Boolean {
+    override fun shouldFire(solution: FiringSolution): Boolean {
         return if (weapon.ship.fluxLevel <= fluxThreshold) {
             true
-        } else if (entity is ShipAPI) {
-            if (Settings.ignoreFighterShields() && entity.isFighter) {
+        } else if (solution.target is ShipAPI) {
+            if (Settings.ignoreFighterShields() && solution.target.isFighter) {
                 true
             } else {
-                val ttt = computeTimeToTravel(weapon, predictedLocation)
-                computeShieldFactor(entity, weapon, ttt)  < shieldThreshold
+                val ttt = computeTimeToTravel(weapon, solution.aimPoint)
+                computeShieldFactor(solution.target, weapon, ttt)  < shieldThreshold
             }
         } else {
             false

--- a/src/main/kotlin/com/dp/advancedgunnerycontrol/weaponais/tags/AvoidShieldsTag.kt
+++ b/src/main/kotlin/com/dp/advancedgunnerycontrol/weaponais/tags/AvoidShieldsTag.kt
@@ -1,27 +1,27 @@
 package com.dp.advancedgunnerycontrol.weaponais.tags
 
 import com.dp.advancedgunnerycontrol.settings.Settings
+import com.dp.advancedgunnerycontrol.weaponais.FiringSolution
 import com.dp.advancedgunnerycontrol.weaponais.computeShieldFactor
 import com.dp.advancedgunnerycontrol.weaponais.computeTimeToTravel
 import com.fs.starfarer.api.combat.CombatEntityAPI
 import com.fs.starfarer.api.combat.ShipAPI
 import com.fs.starfarer.api.combat.WeaponAPI
-import org.lwjgl.util.vector.Vector2f
 
 class AvoidShieldsTag(weapon: WeaponAPI, private val threshold: Float = Settings.avoidShieldsThreshold()) : WeaponAITagBase(weapon) {
 
     override fun isBaseAiValid(entity: CombatEntityAPI): Boolean = computeShieldFactor(entity, weapon) < threshold
 
-    override fun computeTargetPriorityModifier(entity: CombatEntityAPI, predictedLocation: Vector2f): Float {
-        return computeShieldFactor(entity, weapon) + 0.1f
+    override fun computeTargetPriorityModifier(solution: FiringSolution): Float {
+        return computeShieldFactor(solution.target, weapon) + 0.1f
     }
 
-    override fun shouldFire(entity: CombatEntityAPI, predictedLocation: Vector2f): Boolean {
-        val tgtShip = (entity as? ShipAPI) ?: return true
+    override fun shouldFire(solution: FiringSolution): Boolean {
+        val tgtShip = (solution.target as? ShipAPI) ?: return true
         if (Settings.ignoreFighterShields() && tgtShip.isFighter) {
             return true
         }
-        val ttt = computeTimeToTravel(weapon, predictedLocation)
+        val ttt = computeTimeToTravel(weapon, solution.aimPoint)
         return computeShieldFactor(tgtShip, weapon, ttt) < threshold
     }
 

--- a/src/main/kotlin/com/dp/advancedgunnerycontrol/weaponais/tags/BigShipTag.kt
+++ b/src/main/kotlin/com/dp/advancedgunnerycontrol/weaponais/tags/BigShipTag.kt
@@ -1,11 +1,11 @@
 package com.dp.advancedgunnerycontrol.weaponais.tags
 
+import com.dp.advancedgunnerycontrol.weaponais.FiringSolution
 import com.dp.advancedgunnerycontrol.weaponais.bigness
 import com.dp.advancedgunnerycontrol.weaponais.isBig
 import com.fs.starfarer.api.combat.CombatEntityAPI
 import com.fs.starfarer.api.combat.ShipAPI
 import com.fs.starfarer.api.combat.WeaponAPI
-import org.lwjgl.util.vector.Vector2f
 
 class BigShipTag(weapon: WeaponAPI) : WeaponAITagBase(weapon) {
     override fun isValidTarget(entity: CombatEntityAPI): Boolean {
@@ -17,14 +17,14 @@ class BigShipTag(weapon: WeaponAPI) : WeaponAITagBase(weapon) {
         return entity.isCapital || entity.isCruiser
     }
 
-    override fun computeTargetPriorityModifier(entity: CombatEntityAPI, predictedLocation: Vector2f): Float {
-        val tgtShip = (entity as? ShipAPI) ?: return 10000f
+    override fun computeTargetPriorityModifier(solution: FiringSolution): Float {
+        val tgtShip = (solution.target as? ShipAPI) ?: return 10000f
         if(!isBig(tgtShip)) return 10000f
         return 1f/bigness(tgtShip)
     }
 
-    override fun shouldFire(entity: CombatEntityAPI, predictedLocation: Vector2f): Boolean {
-        val tgtShip = (entity as? ShipAPI) ?: return false
+    override fun shouldFire(solution: FiringSolution): Boolean {
+        val tgtShip = (solution.target as? ShipAPI) ?: return false
         return isBig(tgtShip)
     }
 

--- a/src/main/kotlin/com/dp/advancedgunnerycontrol/weaponais/tags/ConserveAmmoTag.kt
+++ b/src/main/kotlin/com/dp/advancedgunnerycontrol/weaponais/tags/ConserveAmmoTag.kt
@@ -1,10 +1,7 @@
 package com.dp.advancedgunnerycontrol.weaponais.tags
 
 import com.dp.advancedgunnerycontrol.settings.Settings
-import com.dp.advancedgunnerycontrol.weaponais.ammoLevel
-import com.dp.advancedgunnerycontrol.weaponais.computeShieldFactor
-import com.dp.advancedgunnerycontrol.weaponais.computeTimeToTravel
-import com.dp.advancedgunnerycontrol.weaponais.isOpportuneTarget
+import com.dp.advancedgunnerycontrol.weaponais.*
 import com.fs.starfarer.api.combat.CombatEntityAPI
 import com.fs.starfarer.api.combat.ShipAPI
 import com.fs.starfarer.api.combat.WeaponAPI
@@ -16,11 +13,11 @@ class ConserveAmmoTag(weapon: WeaponAPI, private val ammoThreshold: Float) : Wea
         return ammoLevel(weapon) > ammoThreshold
     }
 
-    override fun computeTargetPriorityModifier(entity: CombatEntityAPI, predictedLocation: Vector2f): Float = 1f
+    override fun computeTargetPriorityModifier(solution: FiringSolution): Float = 1f
 
-    override fun shouldFire(entity: CombatEntityAPI, predictedLocation: Vector2f): Boolean {
+    override fun shouldFire(solution: FiringSolution): Boolean {
         if(ammoLevel(weapon) < ammoThreshold) {
-            return isOpportuneTarget(entity, entity.location, weapon)
+            return isOpportuneTarget(solution, weapon)
         }
         return true
     }

--- a/src/main/kotlin/com/dp/advancedgunnerycontrol/weaponais/tags/ConservePDAmmoTag.kt
+++ b/src/main/kotlin/com/dp/advancedgunnerycontrol/weaponais/tags/ConservePDAmmoTag.kt
@@ -3,20 +3,19 @@ package com.dp.advancedgunnerycontrol.weaponais.tags
 import com.dp.advancedgunnerycontrol.weaponais.*
 import com.fs.starfarer.api.combat.CombatEntityAPI
 import com.fs.starfarer.api.combat.WeaponAPI
-import org.lwjgl.util.vector.Vector2f
 
 // Only fire at full ROF if target is missile or fighter and ammo < ammoThreshold
 class ConservePDAmmoTag(weapon: WeaponAPI, private val ammoThreshold: Float) : WeaponAITagBase(weapon) {
 
     override fun isBaseAiValid(entity: CombatEntityAPI): Boolean = (ammoLevel(weapon) >= ammoThreshold)
 
-    override fun computeTargetPriorityModifier(entity: CombatEntityAPI, predictedLocation: Vector2f): Float {
-        return if(ammoLevel(weapon) < ammoThreshold && isValidPDTargetForWeapon(entity, weapon)) 0.01f else 1f
+    override fun computeTargetPriorityModifier(solution: FiringSolution): Float {
+        return if(ammoLevel(weapon) < ammoThreshold && isValidPDTargetForWeapon(solution.target, weapon)) 0.01f else 1f
     }
 
-    override fun shouldFire(entity: CombatEntityAPI, predictedLocation: Vector2f): Boolean {
+    override fun shouldFire(solution: FiringSolution): Boolean {
         if(ammoLevel(weapon) < ammoThreshold)  {
-            return isValidPDTargetForWeapon(entity, weapon)
+            return isValidPDTargetForWeapon(solution.target, weapon)
         }
         return true
     }

--- a/src/main/kotlin/com/dp/advancedgunnerycontrol/weaponais/tags/FighterTag.kt
+++ b/src/main/kotlin/com/dp/advancedgunnerycontrol/weaponais/tags/FighterTag.kt
@@ -1,5 +1,6 @@
 package com.dp.advancedgunnerycontrol.weaponais.tags
 
+import com.dp.advancedgunnerycontrol.weaponais.FiringSolution
 import com.fs.starfarer.api.combat.CombatEntityAPI
 import com.fs.starfarer.api.combat.ShipAPI
 import com.fs.starfarer.api.combat.WeaponAPI
@@ -10,9 +11,9 @@ class FighterTag(weapon: WeaponAPI) : WeaponAITagBase(weapon) {
         return (entity as? ShipAPI)?.isFighter == true
     }
 
-    override fun computeTargetPriorityModifier(entity: CombatEntityAPI, predictedLocation: Vector2f): Float = 1.0f
+    override fun computeTargetPriorityModifier(solution: FiringSolution): Float = 1.0f
 
-    override fun shouldFire(entity: CombatEntityAPI, predictedLocation: Vector2f): Boolean = true
+    override fun shouldFire(solution: FiringSolution): Boolean = true
 
     override fun isBaseAiOverridable(): Boolean = true
 

--- a/src/main/kotlin/com/dp/advancedgunnerycontrol/weaponais/tags/FluxTag.kt
+++ b/src/main/kotlin/com/dp/advancedgunnerycontrol/weaponais/tags/FluxTag.kt
@@ -1,5 +1,6 @@
 package com.dp.advancedgunnerycontrol.weaponais.tags
 
+import com.dp.advancedgunnerycontrol.weaponais.FiringSolution
 import com.fs.starfarer.api.combat.CombatEntityAPI
 import com.fs.starfarer.api.combat.ShipAPI
 import com.fs.starfarer.api.combat.WeaponAPI
@@ -12,9 +13,9 @@ class FluxTag(weapon: WeaponAPI, private val threshold: Float) : WeaponAITagBase
         return (weapon.ship?.fluxLevel ?: 0f) <= threshold
     }
 
-    override fun computeTargetPriorityModifier(entity: CombatEntityAPI, predictedLocation: Vector2f): Float = 1.0f
+    override fun computeTargetPriorityModifier(solution: FiringSolution): Float = 1.0f
 
-    override fun shouldFire(entity: CombatEntityAPI, predictedLocation: Vector2f): Boolean{
+    override fun shouldFire(solution: FiringSolution): Boolean{
         return (weapon.ship?.fluxLevel ?: 0f) <= threshold
     }
 

--- a/src/main/kotlin/com/dp/advancedgunnerycontrol/weaponais/tags/ForceAutofireTag.kt
+++ b/src/main/kotlin/com/dp/advancedgunnerycontrol/weaponais/tags/ForceAutofireTag.kt
@@ -1,6 +1,7 @@
 package com.dp.advancedgunnerycontrol.weaponais.tags
 
 import com.dp.advancedgunnerycontrol.utils.getWeaponGroupIndex
+import com.dp.advancedgunnerycontrol.weaponais.FiringSolution
 import com.fs.starfarer.api.combat.CombatEntityAPI
 import com.fs.starfarer.api.combat.WeaponAPI
 import org.lwjgl.util.vector.Vector2f
@@ -10,9 +11,9 @@ class ForceAutofireTag(weapon: WeaponAPI) : WeaponAITagBase(weapon) {
 
     override fun isValidTarget(entity: CombatEntityAPI): Boolean = true
 
-    override fun computeTargetPriorityModifier(entity: CombatEntityAPI, predictedLocation: Vector2f): Float = 1.0f
+    override fun computeTargetPriorityModifier(solution: FiringSolution): Float = 1.0f
 
-    override fun shouldFire(entity: CombatEntityAPI, predictedLocation: Vector2f): Boolean = true
+    override fun shouldFire(solution: FiringSolution): Boolean = true
 
     override fun isBaseAiOverridable(): Boolean = false
 

--- a/src/main/kotlin/com/dp/advancedgunnerycontrol/weaponais/tags/ForceFireTag.kt
+++ b/src/main/kotlin/com/dp/advancedgunnerycontrol/weaponais/tags/ForceFireTag.kt
@@ -1,19 +1,20 @@
 package com.dp.advancedgunnerycontrol.weaponais.tags
 
+import com.dp.advancedgunnerycontrol.weaponais.FiringSolution
 import com.fs.starfarer.api.combat.CombatEntityAPI
 import com.fs.starfarer.api.combat.WeaponAPI
 import org.lwjgl.util.vector.Vector2f
 
 class ForceFireTag(weapon: WeaponAPI, private val fluxThreshold: Float) : WeaponAITagBase(weapon) {
-    override fun computeTargetPriorityModifier(entity: CombatEntityAPI, predictedLocation: Vector2f): Float = 1f
+    override fun computeTargetPriorityModifier(solution: FiringSolution): Float = 1f
 
-    override fun shouldFire(entity: CombatEntityAPI, predictedLocation: Vector2f): Boolean = true
+    override fun shouldFire(solution: FiringSolution): Boolean = true
 
     override fun isBaseAiOverridable(): Boolean = false
 
     override fun avoidDebris(): Boolean = false
 
-    override fun forceFire(entity: CombatEntityAPI?, predictedLocation: Vector2f?, baseDecision: Boolean): Boolean {
+    override fun forceFire(solution: FiringSolution?, baseDecision: Boolean): Boolean {
         return baseDecision && (weapon.ship?.fluxTracker?.fluxLevel ?: 0.0f) < fluxThreshold
     }
 }

--- a/src/main/kotlin/com/dp/advancedgunnerycontrol/weaponais/tags/NoFightersTag.kt
+++ b/src/main/kotlin/com/dp/advancedgunnerycontrol/weaponais/tags/NoFightersTag.kt
@@ -1,5 +1,6 @@
 package com.dp.advancedgunnerycontrol.weaponais.tags
 
+import com.dp.advancedgunnerycontrol.weaponais.FiringSolution
 import com.fs.starfarer.api.combat.CombatEntityAPI
 import com.fs.starfarer.api.combat.ShipAPI
 import com.fs.starfarer.api.combat.WeaponAPI
@@ -10,9 +11,9 @@ class NoFightersTag(weapon: WeaponAPI) : WeaponAITagBase(weapon) {
         return super.isValidTarget(entity) && (entity as? ShipAPI)?.isFighter != true
     }
 
-    override fun computeTargetPriorityModifier(entity: CombatEntityAPI, predictedLocation: Vector2f): Float = 1.0f
+    override fun computeTargetPriorityModifier(solution: FiringSolution): Float = 1.0f
 
-    override fun shouldFire(entity: CombatEntityAPI, predictedLocation: Vector2f): Boolean = true
+    override fun shouldFire(solution: FiringSolution): Boolean = true
 
     override fun isBaseAiOverridable(): Boolean = true
 

--- a/src/main/kotlin/com/dp/advancedgunnerycontrol/weaponais/tags/NoMissilesTag.kt
+++ b/src/main/kotlin/com/dp/advancedgunnerycontrol/weaponais/tags/NoMissilesTag.kt
@@ -1,5 +1,6 @@
 package com.dp.advancedgunnerycontrol.weaponais.tags
 
+import com.dp.advancedgunnerycontrol.weaponais.FiringSolution
 import com.dp.advancedgunnerycontrol.weaponais.isPD
 import com.fs.starfarer.api.combat.CombatEntityAPI
 import com.fs.starfarer.api.combat.MissileAPI
@@ -12,9 +13,9 @@ class NoMissilesTag(weapon: WeaponAPI) : WeaponAITagBase(weapon) {
         return super.isValidTarget(entity) && entity !is MissileAPI
     }
 
-    override fun computeTargetPriorityModifier(entity: CombatEntityAPI, predictedLocation: Vector2f): Float = 1.0f
+    override fun computeTargetPriorityModifier(solution: FiringSolution): Float = 1.0f
 
-    override fun shouldFire(entity: CombatEntityAPI, predictedLocation: Vector2f): Boolean = true
+    override fun shouldFire(solution: FiringSolution): Boolean = true
 
     override fun isBaseAiOverridable(): Boolean = true
 

--- a/src/main/kotlin/com/dp/advancedgunnerycontrol/weaponais/tags/NoPDTag.kt
+++ b/src/main/kotlin/com/dp/advancedgunnerycontrol/weaponais/tags/NoPDTag.kt
@@ -1,10 +1,10 @@
 package com.dp.advancedgunnerycontrol.weaponais.tags
 
+import com.dp.advancedgunnerycontrol.weaponais.FiringSolution
 import com.dp.advancedgunnerycontrol.weaponais.isPD
 import com.fs.starfarer.api.combat.CombatEntityAPI
 import com.fs.starfarer.api.combat.ShipAPI
 import com.fs.starfarer.api.combat.WeaponAPI
-import org.lwjgl.util.vector.Vector2f
 
 class NoPDTag (weapon: WeaponAPI) : WeaponAITagBase(weapon) {
     override fun isBaseAiValid(entity: CombatEntityAPI): Boolean {
@@ -15,12 +15,12 @@ class NoPDTag (weapon: WeaponAPI) : WeaponAITagBase(weapon) {
         return entity is ShipAPI
     }
 
-    override fun computeTargetPriorityModifier(entity: CombatEntityAPI, predictedLocation: Vector2f): Float {
-        val sh = entity as? ShipAPI ?: return 10000f
+    override fun computeTargetPriorityModifier(solution: FiringSolution): Float {
+        val sh = solution.target as? ShipAPI ?: return 10000f
         return if (sh.isFighter) 2.5f else 1f
     }
 
-    override fun shouldFire(entity: CombatEntityAPI, predictedLocation: Vector2f): Boolean = true
+    override fun shouldFire(solution: FiringSolution): Boolean = true
 
     override fun isBaseAiOverridable(): Boolean = true
 

--- a/src/main/kotlin/com/dp/advancedgunnerycontrol/weaponais/tags/OpportunistTag.kt
+++ b/src/main/kotlin/com/dp/advancedgunnerycontrol/weaponais/tags/OpportunistTag.kt
@@ -1,13 +1,9 @@
 package com.dp.advancedgunnerycontrol.weaponais.tags
 
-import com.dp.advancedgunnerycontrol.weaponais.determineIfShotWillHit
-import com.dp.advancedgunnerycontrol.weaponais.effectiveCollRadius
-import com.dp.advancedgunnerycontrol.weaponais.isAimable
-import com.dp.advancedgunnerycontrol.weaponais.isOpportuneTarget
+import com.dp.advancedgunnerycontrol.weaponais.*
 import com.fs.starfarer.api.combat.CombatEntityAPI
 import com.fs.starfarer.api.combat.ShipAPI
 import com.fs.starfarer.api.combat.WeaponAPI
-import org.lwjgl.util.vector.Vector2f
 
 class OpportunistTag(weapon: WeaponAPI) : WeaponAITagBase(weapon) {
     override fun isValidTarget(entity: CombatEntityAPI): Boolean {
@@ -16,19 +12,19 @@ class OpportunistTag(weapon: WeaponAPI) : WeaponAITagBase(weapon) {
 
     override fun isBaseAiValid(entity: CombatEntityAPI): Boolean = false
 
-    override fun computeTargetPriorityModifier(entity: CombatEntityAPI, predictedLocation: Vector2f): Float {
-        return if (isOpportuneTarget(entity, predictedLocation, weapon)) {
+    override fun computeTargetPriorityModifier(solution: FiringSolution): Float {
+        return if (isOpportuneTarget(solution, weapon)) {
             1f
         }else{
             10000.0f
         }
     }
 
-    override fun shouldFire(entity: CombatEntityAPI, predictedLocation: Vector2f): Boolean {
-        if(isAimable(weapon) && !determineIfShotWillHit(predictedLocation, effectiveCollRadius(entity), weapon)){
+    override fun shouldFire(solution: FiringSolution): Boolean {
+        if(isAimable(weapon) && !determineIfShotWillHit(solution.aimPoint, effectiveCollRadius(solution.target), weapon)){
             return false
         }
-        return isOpportuneTarget(entity, predictedLocation, weapon)
+        return isOpportuneTarget(solution, weapon)
     }
 
     override fun isBaseAiOverridable(): Boolean = true

--- a/src/main/kotlin/com/dp/advancedgunnerycontrol/weaponais/tags/PDAtFluxThresholdTag.kt
+++ b/src/main/kotlin/com/dp/advancedgunnerycontrol/weaponais/tags/PDAtFluxThresholdTag.kt
@@ -1,5 +1,6 @@
 package com.dp.advancedgunnerycontrol.weaponais.tags
 
+import com.dp.advancedgunnerycontrol.weaponais.FiringSolution
 import com.dp.advancedgunnerycontrol.weaponais.isPD
 import com.fs.starfarer.api.combat.CombatEntityAPI
 import com.fs.starfarer.api.combat.MissileAPI
@@ -13,9 +14,9 @@ class PDAtFluxThresholdTag(weapon: WeaponAPI, private val threshold: Float) : We
         return (entity as? MissileAPI) != null || (entity as? ShipAPI)?.isFighter == true
     }
 
-    override fun computeTargetPriorityModifier(entity: CombatEntityAPI, predictedLocation: Vector2f): Float = 1.0f
+    override fun computeTargetPriorityModifier(solution: FiringSolution): Float = 1.0f
 
-    override fun shouldFire(entity: CombatEntityAPI, predictedLocation: Vector2f): Boolean = true
+    override fun shouldFire(solution: FiringSolution): Boolean = true
 
     override fun isBaseAiOverridable(): Boolean = false
 

--- a/src/main/kotlin/com/dp/advancedgunnerycontrol/weaponais/tags/PDTag.kt
+++ b/src/main/kotlin/com/dp/advancedgunnerycontrol/weaponais/tags/PDTag.kt
@@ -1,5 +1,6 @@
 package com.dp.advancedgunnerycontrol.weaponais.tags
 
+import com.dp.advancedgunnerycontrol.weaponais.FiringSolution
 import com.dp.advancedgunnerycontrol.weaponais.isPD
 import com.dp.advancedgunnerycontrol.weaponais.isValidPDTargetForWeapon
 import com.fs.starfarer.api.combat.CombatEntityAPI
@@ -13,9 +14,9 @@ class PDTag(weapon: WeaponAPI) : WeaponAITagBase(weapon) {
         return isValidPDTargetForWeapon(entity, weapon)
     }
 
-    override fun computeTargetPriorityModifier(entity: CombatEntityAPI, predictedLocation: Vector2f): Float = 1.0f
+    override fun computeTargetPriorityModifier(solution: FiringSolution): Float = 1.0f
 
-    override fun shouldFire(entity: CombatEntityAPI, predictedLocation: Vector2f): Boolean = true
+    override fun shouldFire(solution: FiringSolution): Boolean = true
 
     override fun isBaseAiOverridable(): Boolean = false
 

--- a/src/main/kotlin/com/dp/advancedgunnerycontrol/weaponais/tags/PanicFireTag.kt
+++ b/src/main/kotlin/com/dp/advancedgunnerycontrol/weaponais/tags/PanicFireTag.kt
@@ -1,6 +1,7 @@
 package com.dp.advancedgunnerycontrol.weaponais.tags
 
 import com.dp.advancedgunnerycontrol.utils.getWeaponGroupIndex
+import com.dp.advancedgunnerycontrol.weaponais.FiringSolution
 import com.fs.starfarer.api.combat.CombatEntityAPI
 import com.fs.starfarer.api.combat.WeaponAPI
 import org.lwjgl.util.vector.Vector2f
@@ -8,16 +9,16 @@ import org.lwjgl.util.vector.Vector2f
 class PanicFireTag(weapon: WeaponAPI, private val threshold: Float) : WeaponAITagBase(weapon) {
     private val groupIndex = getWeaponGroupIndex(weapon)
 
-    override fun computeTargetPriorityModifier(entity: CombatEntityAPI, predictedLocation: Vector2f): Float = 1.0f
+    override fun computeTargetPriorityModifier(solution: FiringSolution): Float = 1.0f
 
-    override fun shouldFire(entity: CombatEntityAPI, predictedLocation: Vector2f): Boolean = true
+    override fun shouldFire(solution: FiringSolution): Boolean = true
 
     override fun isBaseAiOverridable(): Boolean = true
 
     override fun avoidDebris(): Boolean = false
 
-    override fun forceFire(entity: CombatEntityAPI?, predictedLocation: Vector2f?, baseDecision: Boolean): Boolean {
-        return weapon.ship.hullLevel < threshold && entity != null
+    override fun forceFire(solution: FiringSolution?, baseDecision: Boolean): Boolean {
+        return weapon.ship.hullLevel < threshold && solution != null
     }
 
     override val advanceWhenTurnedOff: Boolean = true

--- a/src/main/kotlin/com/dp/advancedgunnerycontrol/weaponais/tags/PhaseTag.kt
+++ b/src/main/kotlin/com/dp/advancedgunnerycontrol/weaponais/tags/PhaseTag.kt
@@ -1,10 +1,10 @@
 package com.dp.advancedgunnerycontrol.weaponais.tags
 
+import com.dp.advancedgunnerycontrol.weaponais.FiringSolution
 import com.dp.advancedgunnerycontrol.weaponais.computeTimeToTravel
 import com.fs.starfarer.api.combat.CombatEntityAPI
 import com.fs.starfarer.api.combat.ShipAPI
 import com.fs.starfarer.api.combat.WeaponAPI
-import org.lwjgl.util.vector.Vector2f
 
 class PhaseTag(weapon: WeaponAPI) : WeaponAITagBase(weapon) {
 
@@ -13,24 +13,24 @@ class PhaseTag(weapon: WeaponAPI) : WeaponAITagBase(weapon) {
         return entity.phaseCloak == null
     }
 
-    override fun computeTargetPriorityModifier(entity: CombatEntityAPI, predictedLocation: Vector2f): Float{
-        if(mayBePhasedWhenShotConnects(entity, predictedLocation)) return 1000f
+    override fun computeTargetPriorityModifier(solution: FiringSolution): Float{
+        if(mayBePhasedWhenShotConnects(solution)) return 1000f
         return 1f
     }
 
-    override fun shouldFire(entity: CombatEntityAPI, predictedLocation: Vector2f): Boolean
-    = !mayBePhasedWhenShotConnects(entity, predictedLocation)
+    override fun shouldFire(solution: FiringSolution): Boolean
+    = !mayBePhasedWhenShotConnects(solution)
 
     override fun isBaseAiOverridable(): Boolean = true
 
     override fun avoidDebris(): Boolean = false
 
-    private fun mayBePhasedWhenShotConnects(entity: CombatEntityAPI, predictedLocation: Vector2f) : Boolean{
-        if (entity !is ShipAPI) return false
-        if (entity.phaseCloak == null) return false
-        val pc = entity.phaseCloak
-        val ft = entity.fluxTracker
-        val ttt = computeTimeToTravel(weapon, predictedLocation)
+    private fun mayBePhasedWhenShotConnects(solution: FiringSolution) : Boolean{
+        if (solution.target !is ShipAPI) return false
+        if (solution.target.phaseCloak == null) return false
+        val pc = solution.target.phaseCloak
+        val ft = solution.target.fluxTracker
+        val ttt = computeTimeToTravel(weapon, solution.aimPoint)
         if (!pc.isActive && (
                     (pc.cooldownRemaining > ttt)
                     || (ft.overloadTimeRemaining > ttt)

--- a/src/main/kotlin/com/dp/advancedgunnerycontrol/weaponais/tags/PrioritisePDTag.kt
+++ b/src/main/kotlin/com/dp/advancedgunnerycontrol/weaponais/tags/PrioritisePDTag.kt
@@ -5,7 +5,6 @@ import com.fs.starfarer.api.combat.CombatEntityAPI
 import com.fs.starfarer.api.combat.MissileAPI
 import com.fs.starfarer.api.combat.ShipAPI
 import com.fs.starfarer.api.combat.WeaponAPI
-import org.lwjgl.util.vector.Vector2f
 
 // Prioritises missiles > fighters > small ships > big ships
 class PrioritisePDTag(weapon: WeaponAPI) : WeaponAITagBase(weapon) {
@@ -15,15 +14,15 @@ class PrioritisePDTag(weapon: WeaponAPI) : WeaponAITagBase(weapon) {
     }
     override fun isBaseAiValid(entity: CombatEntityAPI): Boolean = entity is MissileAPI
 
-    override fun computeTargetPriorityModifier(entity: CombatEntityAPI, predictedLocation: Vector2f): Float {
-        return if (isValidPDTargetForWeapon(entity, weapon)) {
+    override fun computeTargetPriorityModifier(solution: FiringSolution): Float {
+        return if (isValidPDTargetForWeapon(solution.target, weapon)) {
             0.02f
         } else {
-            (entity as? ShipAPI)?.let { bigness(it) } ?: 10f
+            (solution.target as? ShipAPI)?.let { bigness(it) } ?: 10f
         }
     }
 
-    override fun shouldFire(entity: CombatEntityAPI, predictedLocation: Vector2f): Boolean = true
+    override fun shouldFire(solution: FiringSolution): Boolean = true
     override fun isBaseAiOverridable(): Boolean = true
     override fun avoidDebris(): Boolean = false
 }

--- a/src/main/kotlin/com/dp/advancedgunnerycontrol/weaponais/tags/RangeTag.kt
+++ b/src/main/kotlin/com/dp/advancedgunnerycontrol/weaponais/tags/RangeTag.kt
@@ -1,17 +1,18 @@
 package com.dp.advancedgunnerycontrol.weaponais.tags
 
+import com.dp.advancedgunnerycontrol.weaponais.FiringSolution
 import com.fs.starfarer.api.combat.CombatEntityAPI
 import com.fs.starfarer.api.combat.WeaponAPI
 import org.lazywizard.lazylib.ext.minus
 import org.lwjgl.util.vector.Vector2f
 
 class RangeTag(weapon: WeaponAPI, private val threshold: Float) : WeaponAITagBase(weapon) {
-    override fun computeTargetPriorityModifier(entity: CombatEntityAPI, predictedLocation: Vector2f): Float {
-        return if(isInRange(predictedLocation)) 1.0f else 100f
+    override fun computeTargetPriorityModifier(solution: FiringSolution): Float {
+        return if(isInRange(solution.aimPoint)) 1.0f else 100f
     }
 
-    override fun shouldFire(entity: CombatEntityAPI, predictedLocation: Vector2f): Boolean {
-        return isInRange(predictedLocation)
+    override fun shouldFire(solution: FiringSolution): Boolean {
+        return isInRange(solution.aimPoint)
     }
 
     override fun isBaseAiOverridable(): Boolean = true

--- a/src/main/kotlin/com/dp/advancedgunnerycontrol/weaponais/tags/ShipTargetTag.kt
+++ b/src/main/kotlin/com/dp/advancedgunnerycontrol/weaponais/tags/ShipTargetTag.kt
@@ -1,18 +1,18 @@
 package com.dp.advancedgunnerycontrol.weaponais.tags
 
+import com.dp.advancedgunnerycontrol.weaponais.FiringSolution
 import com.fs.starfarer.api.combat.CombatEntityAPI
 import com.fs.starfarer.api.combat.WeaponAPI
-import org.lwjgl.util.vector.Vector2f
 
 class ShipTargetTag(weapon: WeaponAPI) : WeaponAITagBase(weapon) {
     override fun isValidTarget(entity: CombatEntityAPI): Boolean = entityMatchesShipTarget(entity)
 
-    override fun computeTargetPriorityModifier(entity: CombatEntityAPI, predictedLocation: Vector2f): Float {
-        if (entityMatchesShipTarget(entity)) return 0.1f
+    override fun computeTargetPriorityModifier(solution: FiringSolution): Float {
+        if (entityMatchesShipTarget(solution.target)) return 0.1f
         return 100f
     }
 
-    override fun shouldFire(entity: CombatEntityAPI, predictedLocation: Vector2f): Boolean = entityMatchesShipTarget(entity)
+    override fun shouldFire(solution: FiringSolution): Boolean = entityMatchesShipTarget(solution.target)
 
     override fun isBaseAiOverridable(): Boolean = true
 

--- a/src/main/kotlin/com/dp/advancedgunnerycontrol/weaponais/tags/SmallShipTag.kt
+++ b/src/main/kotlin/com/dp/advancedgunnerycontrol/weaponais/tags/SmallShipTag.kt
@@ -1,12 +1,11 @@
 package com.dp.advancedgunnerycontrol.weaponais.tags
 
+import com.dp.advancedgunnerycontrol.weaponais.FiringSolution
 import com.dp.advancedgunnerycontrol.weaponais.bigness
-import com.dp.advancedgunnerycontrol.weaponais.isBig
 import com.dp.advancedgunnerycontrol.weaponais.isSmall
 import com.fs.starfarer.api.combat.CombatEntityAPI
 import com.fs.starfarer.api.combat.ShipAPI
 import com.fs.starfarer.api.combat.WeaponAPI
-import org.lwjgl.util.vector.Vector2f
 
 class SmallShipTag(weapon: WeaponAPI) : WeaponAITagBase(weapon) {
     override fun isValidTarget(entity: CombatEntityAPI): Boolean {
@@ -18,14 +17,14 @@ class SmallShipTag(weapon: WeaponAPI) : WeaponAITagBase(weapon) {
         return entity.isFrigate || entity.isFighter
     }
 
-    override fun computeTargetPriorityModifier(entity: CombatEntityAPI, predictedLocation: Vector2f): Float {
-        val tgtShip = (entity as? ShipAPI) ?: return 10000f
+    override fun computeTargetPriorityModifier(solution: FiringSolution): Float {
+        val tgtShip = (solution.target as? ShipAPI) ?: return 10000f
         if(!isSmall(tgtShip)) return 10000f
         return bigness(tgtShip)
     }
 
-    override fun shouldFire(entity: CombatEntityAPI, predictedLocation: Vector2f): Boolean {
-        val tgtShip = (entity as? ShipAPI) ?: return false
+    override fun shouldFire(solution: FiringSolution): Boolean {
+        val tgtShip = (solution.target as? ShipAPI) ?: return false
         return isSmall(tgtShip)
     }
 

--- a/src/main/kotlin/com/dp/advancedgunnerycontrol/weaponais/tags/TargetShieldsAtFTTag.kt
+++ b/src/main/kotlin/com/dp/advancedgunnerycontrol/weaponais/tags/TargetShieldsAtFTTag.kt
@@ -1,12 +1,12 @@
 package com.dp.advancedgunnerycontrol.weaponais.tags
 
 import com.dp.advancedgunnerycontrol.settings.Settings
+import com.dp.advancedgunnerycontrol.weaponais.FiringSolution
 import com.dp.advancedgunnerycontrol.weaponais.computeShieldFactor
 import com.dp.advancedgunnerycontrol.weaponais.computeTimeToTravel
 import com.fs.starfarer.api.combat.CombatEntityAPI
 import com.fs.starfarer.api.combat.ShipAPI
 import com.fs.starfarer.api.combat.WeaponAPI
-import org.lwjgl.util.vector.Vector2f
 
 // Allows targeting of anything when flux < fluxThreshold, otherwise target shields. Always prioritises by target shield factor
 class TargetShieldsAtFTTag(
@@ -22,20 +22,20 @@ class TargetShieldsAtFTTag(
             computeShieldFactor(entity, weapon) > shieldThreshold
         }
     }
-    override fun computeTargetPriorityModifier(entity: CombatEntityAPI, predictedLocation: Vector2f): Float {
-        val tgtShip = (entity as? ShipAPI) ?: return 1f
+    override fun computeTargetPriorityModifier(solution: FiringSolution): Float {
+        val tgtShip = (solution.target as? ShipAPI) ?: return 1f
         return 1f/(computeShieldFactor(tgtShip, weapon) + 0.5f)
     }
 
-    override fun shouldFire(entity: CombatEntityAPI, predictedLocation: Vector2f): Boolean {
+    override fun shouldFire(solution: FiringSolution): Boolean {
         return if (weapon.ship.fluxLevel <= fluxThreshold) {
             true
-        } else if (entity is ShipAPI) {
-            if (Settings.ignoreFighterShields() && entity.isFighter) {
+        } else if (solution.target is ShipAPI) {
+            if (Settings.ignoreFighterShields() && solution.target.isFighter) {
                 true
             } else {
-                val ttt = computeTimeToTravel(weapon, predictedLocation)
-                computeShieldFactor(entity, weapon, ttt) > shieldThreshold
+                val ttt = computeTimeToTravel(weapon, solution.aimPoint)
+                computeShieldFactor(solution.target, weapon, ttt) > shieldThreshold
             }
         } else {
             false

--- a/src/main/kotlin/com/dp/advancedgunnerycontrol/weaponais/tags/TargetShieldsTag.kt
+++ b/src/main/kotlin/com/dp/advancedgunnerycontrol/weaponais/tags/TargetShieldsTag.kt
@@ -1,29 +1,29 @@
 package com.dp.advancedgunnerycontrol.weaponais.tags
 
 import com.dp.advancedgunnerycontrol.settings.Settings
+import com.dp.advancedgunnerycontrol.weaponais.FiringSolution
 import com.dp.advancedgunnerycontrol.weaponais.computeShieldFactor
 import com.dp.advancedgunnerycontrol.weaponais.computeTimeToTravel
 import com.fs.starfarer.api.combat.CombatEntityAPI
 import com.fs.starfarer.api.combat.ShipAPI
 import com.fs.starfarer.api.combat.WeaponAPI
-import org.lwjgl.util.vector.Vector2f
 
 class TargetShieldsTag(weapon: WeaponAPI, private val threshold: Float = Settings.targetShieldsThreshold()) : WeaponAITagBase(weapon) {
 
     override fun isBaseAiValid(entity: CombatEntityAPI): Boolean {
         return computeShieldFactor(entity, weapon) > threshold
     }
-    override fun computeTargetPriorityModifier(entity: CombatEntityAPI, predictedLocation: Vector2f): Float {
-        val tgtShip = (entity as? ShipAPI) ?: return 1f
+    override fun computeTargetPriorityModifier(solution: FiringSolution): Float {
+        val tgtShip = (solution.target as? ShipAPI) ?: return 1f
         return 1f/(computeShieldFactor(tgtShip, weapon) + 0.5f)
     }
 
-    override fun shouldFire(entity: CombatEntityAPI, predictedLocation: Vector2f): Boolean {
-        val tgtShip = (entity as? ShipAPI) ?: return false
+    override fun shouldFire(solution: FiringSolution): Boolean {
+        val tgtShip = (solution.target as? ShipAPI) ?: return false
         if (Settings.ignoreFighterShields() && tgtShip.isFighter) {
             return true
         }
-        val ttt = computeTimeToTravel(weapon, predictedLocation)
+        val ttt = computeTimeToTravel(weapon, solution.aimPoint)
         return computeShieldFactor(tgtShip, weapon, ttt) > threshold
     }
 

--- a/src/main/kotlin/com/dp/advancedgunnerycontrol/weaponais/tags/WeaponAITagBase.kt
+++ b/src/main/kotlin/com/dp/advancedgunnerycontrol/weaponais/tags/WeaponAITagBase.kt
@@ -4,6 +4,7 @@ import com.dp.advancedgunnerycontrol.settings.Settings
 import com.dp.advancedgunnerycontrol.typesandvalues.assignShipMode
 import com.dp.advancedgunnerycontrol.typesandvalues.hasCustomAI
 import com.dp.advancedgunnerycontrol.typesandvalues.getCustomShipAI
+import com.dp.advancedgunnerycontrol.weaponais.FiringSolution
 import com.dp.advancedgunnerycontrol.weaponais.isPD
 import com.dp.advancedgunnerycontrol.weaponais.shipais.ShipCommandWrapper
 import com.fs.starfarer.api.combat.CombatEntityAPI
@@ -20,8 +21,8 @@ abstract class WeaponAITagBase(protected val weapon: WeaponAPI) {
         }
         return true
     }
-    abstract fun computeTargetPriorityModifier(entity: CombatEntityAPI, predictedLocation: Vector2f) : Float
-    abstract fun shouldFire(entity: CombatEntityAPI, predictedLocation: Vector2f) : Boolean
+    abstract fun computeTargetPriorityModifier(solution: FiringSolution) : Float
+    abstract fun shouldFire(solution: FiringSolution) : Boolean
     abstract fun isBaseAiOverridable() : Boolean
     abstract fun avoidDebris() : Boolean
 
@@ -32,7 +33,7 @@ abstract class WeaponAITagBase(protected val weapon: WeaponAPI) {
     open fun isValid() : Boolean {
         return !Settings.weaponBlacklist.contains(weapon.id)
     }
-    open fun forceFire(entity: CombatEntityAPI?, predictedLocation: Vector2f?, baseDecision: Boolean) : Boolean = false
+    open fun forceFire(solution: FiringSolution?, baseDecision: Boolean) : Boolean = false
     open fun advance(){}
     // Note: if true, advance will be called every frame, even if the weapon group is not set to autofire!
     open val advanceWhenTurnedOff : Boolean = false


### PR DESCRIPTION
`FiringSolution` data class combines `targetEntity` and `targetPoint` variables into one. That way passing the variables can be done without using `Pair<>`.

`FiringSolution` is supposed to be easily extendable with additional pre-calculated values used by tags, like `timeToHit` or simillar.

The changes are (almost, see comment below) only code refactor, not affecting the behavior.